### PR TITLE
Use a timeout for placing items on the queue.

### DIFF
--- a/cpc/dataflow/task.py
+++ b/cpc/dataflow/task.py
@@ -57,7 +57,9 @@ class TaskQueue(object):
 
     def put(self, task):
         """Put a task in the queue."""
-        self.queue.put(task)
+        # Use a timeout in order to avoid freezing the server completely
+        # if the queue is full.
+        self.queue.put(task, timeout=15)
 
     def putNone(self):
         """Put a none into the queue to make sure threads are reading it."""


### PR DESCRIPTION
Without a timeout there is a block until a free slot is available.
This can freeze the server completely. Adding a timeout means that
it will at least be accessible, and tests have shown that it
continues executing just fine without reaching the timeout.
