### PR TITLE
When servers sends HTTPS requests to eachother both sides require ssl…

### DIFF
--- a/cpc-server
+++ b/cpc-server
@@ -44,7 +44,7 @@ from cpc.util.version import __version__
 
 
 def print_usage():
-    print "Usage: cpc-server start [-dev]"
+    print "Usage: cpc-server start [-dev] [-no-server-verification]"
     print "       cpc-server config-list"
     print "       cpc-server config-values"
     print "       cpc-server config param value"
@@ -131,6 +131,11 @@ try:
 
                 cpc.util.log.initServerLogToStdout(serverMode)
                 doFork = False
+            if '-no-server-verification' in args:
+                cf.setServerVerification(False)
+                print "Server will allow requests from connected servers on the client port. " \
+                      "This means that the connecting servers will not be athuenticated in any way. " \
+                      "Only use this setting in cases where you have openssl incompatibilites between servers."
         print "Starting server.."
 
         doProfile = cf.getProfiling()

--- a/cpc/network/com/client_base.py
+++ b/cpc/network/com/client_base.py
@@ -19,6 +19,7 @@
 
 import httplib
 import socket
+import ssl
 import logging
 import cpc.util.log
 import client_connection
@@ -65,6 +66,7 @@ class ClientBase(object):
         self.port = port
         self.conf = conf
         self.require_certificate_authentication = None
+        self.useNoSSLFalback=False
 
     def putRequest(self, req, require_certificate_authentication=None, disable_cookies=False):
         self.__connect(require_certificate_authentication, disable_cookies)

--- a/cpc/network/http/http_method_parser.py
+++ b/cpc/network/http/http_method_parser.py
@@ -95,12 +95,12 @@ class HttpMethodParser(object):
         contentLength = long(headers['content-length'])
         if headers['content-type'] == 'application/x-www-form-urlencoded' or headers['content-type'] == 'application/x-www-form-urlencoded; charset=UTF-8': #TODO generalize
             msg =  message.read(contentLength)
-            log.log(cpc.util.log.TRACE,'RAW msg is %s'%msg)
             parsedDict = urlparse.parse_qs(msg)  #Note values here are stored in lists, this is so one can handle many inputs with same name, for now we dont want that as our multipart parsing does not support it
             params = dict()
             for k,v in parsedDict.iteritems():
                 params[k] = v[0]
 
+            log.log(cpc.util.log.TRACE,'msg is %s'%params)
             request = ServerRequest(headers,None,params)
 
         return request

--- a/cpc/network/https/real_https_connection.py
+++ b/cpc/network/https/real_https_connection.py
@@ -70,14 +70,19 @@ class HttpsConnectionWithCertReq(httplib.HTTPConnection):
         sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
         #create an ssl context and load certificate verify locations
-        self.sock = ssl.wrap_socket(sock,
-                                    self.privateKeyFile,
-                                    self.certFile,
-                                    cert_reqs = ssl.CERT_REQUIRED,
-                                    ssl_version=ssl.PROTOCOL_SSLv3,
-                                    ca_certs=self.caFile)
-        self.sock.connect((self.host,self.port))
-        self.connected = True
+        try:
+            self.sock = ssl.wrap_socket(sock,
+                                        self.privateKeyFile,
+                                        self.certFile,
+                                        cert_reqs = ssl.CERT_REQUIRED,
+                                        ssl_version=ssl.PROTOCOL_SSLv3,
+                                        ca_certs=self.caFile)
+            self.sock.connect((self.host,self.port))
+            self.connected = True
+
+        except ssl.SSLError as e:
+            log.error(e)
+            raise
 
 class HttpsConnectionNoCertReq(httplib.HTTPConnection):
     '''
@@ -93,10 +98,16 @@ class HttpsConnectionNoCertReq(httplib.HTTPConnection):
 
 
     def connect(self):
-        sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
-        #create an ssl context and load certificate verify locations
-        self.sock = ssl.wrap_socket(sock,
-                                    cert_reqs = ssl.CERT_NONE,
-                                    ssl_version=ssl.PROTOCOL_SSLv3)
-        self.sock.connect((self.host,self.port))
+        try:
+            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+            #create an ssl context and load certificate verify locations
+            self.sock = ssl.wrap_socket(sock,
+                                        cert_reqs = ssl.CERT_NONE,
+                                        ssl_version=ssl.PROTOCOL_SSLv3)
+            self.sock.connect((self.host,self.port))
+
+        except ssl.SSLError as e:
+            log.error(e)
+            raise

--- a/cpc/network/request_handler.py
+++ b/cpc/network/request_handler.py
@@ -357,6 +357,18 @@ class handlerForRequestWithNoCertReq(handler_base):
     def setup(self):
         handler_base.setup(self)
         self.log=logging.getLogger(__name__)
+        ##is this a request from a server and have
+
+    def _handleSession(self, request):
+        handler_base._handleSession(self,request)
+
+        if 'user' not in request.session \
+                and not ServerConf().getServerVerification() \
+                and self.headers.has_key('originating-server-id'):
+
+            if ServerConf().getNodes().exists(self.headers['originating-server-id']):
+                request.session['user'] = User(1, 'root', UserLevel.SUPERUSER)
+
 
 
 class handlerForRequestWithCertReq(handler_base):

--- a/cpc/util/conf/conf_base.py
+++ b/cpc/util/conf/conf_base.py
@@ -389,13 +389,7 @@ class Conf:
         # construct a dict with only the values that have changed from 
         # the default values
         conf = dict()
-        for cf in self.conf.itervalues():
-            if cf.hasSetValue():
-                conf[cf.name] = cf.get()
-            # and write out that dict.
-        f.write(json.dumps(conf,
-            default=cpc.util.json_serializer.toJson,
-            indent=4))
+        f.write(self.toJson())
         f.close()
 
 
@@ -404,11 +398,11 @@ class Conf:
         returns a json formatted string
         @return json String
         '''
-
         with self.lock:
             conf = dict()
             for cf in self.conf.itervalues():
-                if cf.writable:
+                if cf.hasSetValue() and cf.writable:
+
                     conf[cf.name] = cf.get()
 
             return json.dumps(conf,

--- a/cpc/util/conf/connection_bundle.py
+++ b/cpc/util/conf/connection_bundle.py
@@ -106,7 +106,7 @@ class ConnectionBundle(Conf):
     #overrrides method in ConfBase
     def initDefaults(self):
         self._add('client_host', self.client_host,
-                  "Hostname for the client to connect to", True)
+                  "Hostname for the client to connect to", True,None)
         self._add('server_secure_port', Conf.getDefaultServerSecurePort(),
                    "Port number the server uses for communication from servers ",
                    True,None,'\d+')

--- a/cpc/util/conf/server_conf.py
+++ b/cpc/util/conf/server_conf.py
@@ -243,6 +243,12 @@ class ServerConf(conf_base.Conf):
             "value is in seconds"
             ,userSettable=True)
 
+        self._add('server_verification',True,
+                  "By default servers should always require ssl certificate from both directions" \
+                  "setting this to true will let the sending server to use the client port and disregard" \
+                  "certificate checks. This should only be used in very rare circumstances, for example when debugging" \
+                  "ssl incombatibilites between machines " ,writable=False
+                  ,userSettable=False)
 
         dn=os.path.dirname(sys.argv[0])
         self.execBasedir = ''
@@ -256,6 +262,10 @@ class ServerConf(conf_base.Conf):
         else:
             os.environ['PYTHONPATH'] = self.execBasedir
 
+
+    def setServerVerification(self,doVerify):
+        self.set('server_verification',doVerify)
+        return
 
     def setServerHost(self,serverAddress):
         self.set('server_host',serverAddress)
@@ -326,11 +336,15 @@ class ServerConf(conf_base.Conf):
         with self.lock:
             return self.conf.get('nodes').get()
 
+    def getServerVerification(self):
+        return self.get('server_verification')
+
     def getNodeConnectRequests(self):
         return self.get('node_connect_requests')
 
     def getSentNodeConnectRequests(self):
         return self.get('sent_node_connect_requests')
+
     def getLogDir(self):
         return self.getFile('log_dir')
 

--- a/cpc/util/log/log.py
+++ b/cpc/util/log/log.py
@@ -48,7 +48,7 @@ def initClientLog(debug=False):
        stdout."""
     logger=logging.getLogger('cpc')
     if debug:
-        logger.setLevel(logging.DEBUG)
+        logger.setLevel(TRACE)
     else:
         logger.setLevel(logging.INFO)
 

--- a/cpc/util/openssl.py
+++ b/cpc/util/openssl.py
@@ -104,6 +104,7 @@ class OpenSSL(object):
             serverConf.getClientSecurePort())
         connectionBundle.setServerSecurePort(
             serverConf.getServerSecurePort())
+        connectionBundle.setHostname(ServerConf().getHostName())
         return connectionBundle
 
     def setupServer(self):

--- a/cpc/worker/message.py
+++ b/cpc/worker/message.py
@@ -45,7 +45,7 @@ class WorkerMessage(ClientBase):
             self.host = self.conf.getClientHost()
         if self.port == None:
             self.port = self.conf.getServerSecurePort()
-        
+
         self.require_certificate_authentication=True
         self.privateKey = self.conf.getPrivateKey()
         self.keychain = self.conf.getCaChainFile()


### PR DESCRIPTION
… authentication

in the handshaking procedure. On some environments this does not work
well due to openssl incompatibilites. For debugging purposes and
resolving incompatibilites the server setting -no-server-verification is
introduces.
When a server is started with -no-server-verification it will allow
other servers to connect withouth requiring any handshaking procedure.
This means that no certificate authentication takes place
The server that sends a request will first try on the standard 13807
port. if that does not work it will try on port 14807.
The server that receives the request will check if
-no-server-verification is on and if the sending server is in the Nodes
list.
