### PR TITLE
Remove use of SSLv3

### DIFF
--- a/cpc/network/https/real_https_connection.py
+++ b/cpc/network/https/real_https_connection.py
@@ -75,7 +75,6 @@ class HttpsConnectionWithCertReq(httplib.HTTPConnection):
                                         self.privateKeyFile,
                                         self.certFile,
                                         cert_reqs = ssl.CERT_REQUIRED,
-                                        ssl_version=ssl.PROTOCOL_SSLv3,
                                         ca_certs=self.caFile)
             self.sock.connect((self.host,self.port))
             self.connected = True
@@ -104,8 +103,7 @@ class HttpsConnectionNoCertReq(httplib.HTTPConnection):
 
             #create an ssl context and load certificate verify locations
             self.sock = ssl.wrap_socket(sock,
-                                        cert_reqs = ssl.CERT_NONE,
-                                        ssl_version=ssl.PROTOCOL_SSLv3)
+                                        cert_reqs = ssl.CERT_NONE)
             self.sock.connect((self.host,self.port))
 
         except ssl.SSLError as e:

--- a/cpc/network/server.py
+++ b/cpc/network/server.py
@@ -69,7 +69,6 @@ class HTTPSServerWithCertAuthentication(CopernicusServer):
         try:
             self.socket =  ssl.wrap_socket(sock, fpem, fcert, server_side=True,\
                                            cert_reqs = ssl.CERT_REQUIRED,
-                                           ssl_version=ssl.PROTOCOL_SSLv3,
                                            ca_certs=ca
                                            )
             self.server_bind()
@@ -106,7 +105,6 @@ class HTTPSServerNoCertAuthentication(HTTPServer__base):
         try:
             self.socket =  ssl.wrap_socket(sock, fpem, fcert, server_side=True,\
                                            cert_reqs = ssl.CERT_NONE,
-                                           ssl_version=ssl.PROTOCOL_SSLv3,
                                            ca_certs=ca)
             self.server_bind()
             self.server_activate()


### PR DESCRIPTION
SSLv3 was the subject of the POODLE fiasco of the last year, and nobody is supporting it anymore.

Use SSLv23 instead (the default) it actually will negotiate the highest level common to the server and client (including TLS). Also, recent python versions disable v2 and v3 by default.

https://docs.python.org/2/library/ssl.html#socket-creation
